### PR TITLE
[3.3.3] Add integrations RPC config for docker and remove repeated edges config

### DIFF
--- a/advanced/docker-compose.prometheus-grafana.yml
+++ b/advanced/docker-compose.prometheus-grafana.yml
@@ -45,7 +45,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
-      - 9090:9090
+      - 9090
     restart: always
   grafana:
     image: grafana/grafana

--- a/advanced/docker-compose.yml
+++ b/advanced/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     ports:
       - "8080"
       - "7070"
+      - "9090"
     logging:
       driver: "json-file"
       options:
@@ -85,6 +86,7 @@ services:
     ports:
       - "8080"
       - "7070"
+      - "9090"
     logging:
       driver: "json-file"
       options:
@@ -289,6 +291,7 @@ services:
      - "443:443"
      - "1883:1883"
      - "7070:7070"
+     - "9090:9090"
      - "9999:9999"
     cap_add:
      - NET_ADMIN
@@ -297,6 +300,7 @@ services:
       HTTPS_PORT: 443
       MQTT_PORT: 1883
       EDGES_RPC_PORT: 7070
+      INTEGRATIONS_RPC_PORT: 9090
       WEBREPORT_PORT: 8383
       FORCE_HTTPS_REDIRECT: "false"
     links:

--- a/advanced/haproxy/config/haproxy.cfg
+++ b/advanced/haproxy/config/haproxy.cfg
@@ -60,6 +60,17 @@ listen edges-rpc-in
  server tbEdgesRpc1 tb-core1:7070 check inter 5s resolvers docker_resolver resolve-prefer ipv4
  server tbEdgesRpc2 tb-core2:7070 check inter 5s resolvers docker_resolver resolve-prefer ipv4
 
+listen integrations-rpc-in
+ bind *:${INTEGRATIONS_RPC_PORT}
+ mode tcp
+ option clitcpka # For TCP keep-alive
+ timeout client 3h
+ timeout server 3h
+ option tcplog
+ balance leastconn
+ server tbIntegrationsRpc1 tb-core1:9090 check inter 5s resolvers docker_resolver resolve-prefer ipv4
+ server tbIntegrationsRpc2 tb-core2:9090 check inter 5s resolvers docker_resolver resolve-prefer ipv4
+
 frontend http-in
  bind *:${HTTP_PORT} alpn h2,http/1.1
 

--- a/basic/docker-compose.prometheus-grafana.yml
+++ b/basic/docker-compose.prometheus-grafana.yml
@@ -45,7 +45,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
-      - 9090:9090
+      - 9090
     restart: always
   grafana:
     image: grafana/grafana

--- a/basic/docker-compose.yml
+++ b/basic/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     ports:
       - "8080"
       - "7070"
+      - "9090"
     logging:
       driver: "json-file"
       options:
@@ -177,6 +178,7 @@ services:
      - "443:443"
      - "1883:1883"
      - "7070:7070"
+     - "9090:9090"
      - "9999:9999"
     cap_add:
      - NET_ADMIN
@@ -186,6 +188,7 @@ services:
       MQTT_PORT: 1883
       EDGES_RPC_PORT: 7070
       WEBREPORT_PORT: 8383
+      INTEGRATIONS_RPC_PORT: 9090
       FORCE_HTTPS_REDIRECT: "false"
     links:
         - tb-monolith

--- a/basic/haproxy/config/haproxy.cfg
+++ b/basic/haproxy/config/haproxy.cfg
@@ -58,6 +58,16 @@ listen edges-rpc-in
  balance leastconn
  server tbEdgesRpc tb-monolith:7070 check inter 5s resolvers docker_resolver resolve-prefer ipv4
 
+listen integrations-rpc-in
+ bind *:${INTEGRATIONS_RPC_PORT}
+ mode tcp
+ option clitcpka # For TCP keep-alive
+ timeout client 3h
+ timeout server 3h
+ option tcplog
+ balance leastconn
+ server tbIntegrationsRpc tb-monolith:9090 check inter 5s resolvers docker_resolver resolve-prefer ipv4
+
 frontend http-in
  bind *:${HTTP_PORT} alpn h2,http/1.1
 

--- a/monolith/docker-compose.prometheus-grafana.yml
+++ b/monolith/docker-compose.prometheus-grafana.yml
@@ -45,7 +45,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
-      - 9090:9090
+      - 9090
     restart: always
   grafana:
     image: grafana/grafana

--- a/monolith/docker-compose.yml
+++ b/monolith/docker-compose.yml
@@ -58,8 +58,8 @@ services:
     ports:
       - "8080"
       - "7070"
+      - "9090"
       - "1883"
-      - "7070"
       - "5683:5683/udp"
       - "5685:5685/udp"
     logging:
@@ -101,6 +101,7 @@ services:
      - "443:443"
      - "1883:1883"
      - "7070:7070"
+     - "9090:9090"
      - "9999:9999"
     cap_add:
      - NET_ADMIN
@@ -110,7 +111,7 @@ services:
       MQTT_PORT: 1883
       EDGES_RPC_PORT: 7070
       WEBREPORT_PORT: 8383
-      EDGES_RPC_PORT: 7070
+      INTEGRATIONS_RPC_PORT: 9090
       FORCE_HTTPS_REDIRECT: "false"
     links:
         - tb-monolith

--- a/monolith/haproxy/config/haproxy.cfg
+++ b/monolith/haproxy/config/haproxy.cfg
@@ -58,6 +58,16 @@ listen edges-rpc-in
  balance leastconn
  server tbEdgesRpc tb-monolith:7070 check inter 5s resolvers docker_resolver resolve-prefer ipv4
 
+listen integrations-rpc-in
+ bind *:${INTEGRATIONS_RPC_PORT}
+ mode tcp
+ option clitcpka # For TCP keep-alive
+ timeout client 3h
+ timeout server 3h
+ option tcplog
+ balance leastconn
+ server tbIntegrationsRpc tb-monolith:9090 check inter 5s resolvers docker_resolver resolve-prefer ipv4
+
 frontend http-in
  bind *:${HTTP_PORT} alpn h2,http/1.1
 


### PR DESCRIPTION
When I start TB in docker and want to connect with RPC, I cannot make this, because docker-compose.yml doesn't have a config for this operation. So I add this setting to docker-compose.yml files. 
Also in monolith/docker-compose.yml code have repeat config for EDGE_RPC. IDEA says error for this situation, so I replace this mistake.

Please merge this PR before the https://github.com/thingsboard/thingsboard-pe/pull/642