### PR TITLE
[3.4] Folders permission check and set on startup 

### DIFF
--- a/compose-utils.sh
+++ b/compose-utils.sh
@@ -176,3 +176,82 @@ function additionalStartupServices() {
 
     echo $ADDITIONAL_STARTUP_SERVICES
 }
+
+function permissionList() {
+    PERMISSION_LIST="
+      799  799  tb-node/log
+      799  799  tb-transports/coap/log
+      799  799  tb-transports/lwm2m/log
+      799  799  tb-transports/http/log
+      799  799  tb-transports/mqtt/log
+      799  799  tb-transports/snmp/log
+      799  799  tb-transports/coap/log
+      799  799  tb-vc-executor/log
+      999  999  tb-node/postgres
+      "
+
+    PERMISSION_LIST="$PERMISSION_LIST
+      799  799  tb-node/data
+      799  799  tb-integration-executor/log
+      "
+
+    source .env
+
+    if [ "$DATABASE" = "hybrid" ]; then
+      PERMISSION_LIST="$PERMISSION_LIST
+      999  999  tb-node/cassandra
+      "
+    fi
+
+    CACHE="${CACHE:-redis}"
+    case $CACHE in
+        redis)
+          PERMISSION_LIST="$PERMISSION_LIST
+          1001 1001 tb-node/redis-data
+          "
+        ;;
+        redis-cluster)
+          PERMISSION_LIST="$PERMISSION_LIST
+          1001 1001 tb-node/redis-cluster-data-0
+          1001 1001 tb-node/redis-cluster-data-1
+          1001 1001 tb-node/redis-cluster-data-2
+          1001 1001 tb-node/redis-cluster-data-3
+          1001 1001 tb-node/redis-cluster-data-4
+          1001 1001 tb-node/redis-cluster-data-5
+          "
+        ;;
+        *)
+        echo "Unknown CACHE value specified in the .env file: '${CACHE}'. Should be either 'redis' or 'redis-cluster'." >&2
+        exit 1
+    esac
+
+    echo "$PERMISSION_LIST"
+}
+
+function checkFolders() {
+  EXIT_CODE=0
+  PERMISSION_LIST=$(permissionList) || exit $?
+  set -e
+  while read -r USR GRP DIR
+  do
+    if [ -z "$DIR" ]; then # skip empty lines
+          continue
+    fi
+    MESSAGE="Checking user ${USR} group ${GRP} dir ${DIR}"
+    if [[ -d "$DIR" ]] &&
+       [[ $(ls -ldn "$DIR" | awk '{print $3}') -eq "$USR" ]] &&
+       [[ $(ls -ldn "$DIR" | awk '{print $4}') -eq "$GRP" ]]
+    then
+      MESSAGE="$MESSAGE OK"
+    else
+      if [ "$1" = "--create" ]; then
+        echo "Create and chown: user ${USR} group ${GRP} dir ${DIR}"
+        mkdir -p "$DIR" && sudo chown -R "$USR":"$GRP" "$DIR"
+      else
+        echo "$MESSAGE FAILED"
+        EXIT_CODE=1
+      fi
+    fi
+  done < <(echo "$PERMISSION_LIST")
+  return $EXIT_CODE
+}

--- a/docker-check-log-folders.sh
+++ b/docker-check-log-folders.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
 #
 # ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
 #
-# Copyright © 2016-2019 ThingsBoard, Inc. All Rights Reserved.
+# Copyright © 2016-2022 ThingsBoard, Inc. All Rights Reserved.
 #
 # NOTICE: All information contained herein is, and remains
 # the property of ThingsBoard, Inc. and its suppliers,
@@ -31,4 +32,5 @@
 
 set -e
 source compose-utils.sh
-checkFolders --create
+checkFolders || exit $?
+echo "OK"

--- a/docker-install-tb.sh
+++ b/docker-install-tb.sh
@@ -68,6 +68,8 @@ ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
 
 ADDITIONAL_STARTUP_SERVICES=$(additionalStartupServices) || exit $?
 
+checkFolders --create || exit $?
+
 cd $DEPLOYMENT_FOLDER
 
 if [ ! -z "${ADDITIONAL_STARTUP_SERVICES// }" ]; then

--- a/docker-start-services.sh
+++ b/docker-start-services.sh
@@ -44,6 +44,8 @@ ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
 
 ADDITIONAL_COMPOSE_MONITORING_ARGS=$(additionalComposeMonitoringArgs) || exit $?
 
+checkFolders --create || exit $?
+
 cd $DEPLOYMENT_FOLDER
 
 docker-compose \

--- a/docker-upgrade-tb.sh
+++ b/docker-upgrade-tb.sh
@@ -67,6 +67,8 @@ ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
 
 ADDITIONAL_STARTUP_SERVICES=$(additionalStartupServices) || exit $?
 
+checkFolders --create || exit $?
+
 cd $DEPLOYMENT_FOLDER
 
 docker-compose \


### PR DESCRIPTION
# Folders permission check and set on startup

Here the sample output:

![image](https://user-images.githubusercontent.com/79898499/176231568-fbe68ed1-29b8-48b4-bfe1-ab94671db322.png)

When the permissions are fine, the checker stays silent.

This is merged from CE:
https://github.com/thingsboard/thingsboard/pull/6847