### PR TITLE
[3.4.2] configured max-old-space-size for js-executor

### DIFF
--- a/tb-js-executor.env
+++ b/tb-js-executor.env
@@ -4,3 +4,4 @@ LOG_FOLDER=logs
 LOGGER_FILENAME=tb-js-executor-%DATE%.log
 DOCKER_MODE=true
 SCRIPT_BODY_TRACE_FREQUENCY=1000
+NODE_OPTIONS="--max-old-space-size=200"


### PR DESCRIPTION
https://github.com/thingsboard/thingsboard/pull/7613