### PR TITLE
Compatibility with Compose V2

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # advanced, basic, monolith
-TB_SETUP=advanced
+TB_SETUP=basic
 
 TB_QUEUE_TYPE=kafka
 

--- a/advanced/docker-compose.yml
+++ b/advanced/docker-compose.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '2.2'
-
 services:
   zookeeper:
     restart: always
@@ -44,7 +42,8 @@ services:
   tb-js-executor:
     restart: always
     image: "${DOCKER_REPO}/${JS_EXECUTOR_DOCKER_NAME}:${TB_VERSION}"
-    scale: 10
+    deploy:
+      replicas: 10
     env_file:
       - ../tb-js-executor.env
   tb-core1:

--- a/basic/docker-compose.yml
+++ b/basic/docker-compose.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '2.2'
-
 services:
   zookeeper:
     restart: always
@@ -44,7 +42,8 @@ services:
   tb-js-executor:
     restart: always
     image: "${DOCKER_REPO}/${JS_EXECUTOR_DOCKER_NAME}:${TB_VERSION}"
-    scale: 10
+    deploy:
+      replicas: 10
     env_file:
       - ../tb-js-executor.env
   tb-monolith:

--- a/compose-utils.sh
+++ b/compose-utils.sh
@@ -2,7 +2,7 @@
 #
 # ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
 #
-# Copyright © 2016-2019 ThingsBoard, Inc. All Rights Reserved.
+# Copyright © 2016-2022 ThingsBoard, Inc. All Rights Reserved.
 #
 # NOTICE: All information contained herein is, and remains
 # the property of ThingsBoard, Inc. and its suppliers,
@@ -254,4 +254,36 @@ function checkFolders() {
     fi
   done < <(echo "$PERMISSION_LIST")
   return $EXIT_CODE
+}
+
+function composeVersion() {
+    #Checking whether "set -e" shell option should be restored after Compose version check
+    FLAG_SET=false
+    if [[ $SHELLOPTS =~ errexit ]]; then
+        set +e
+        FLAG_SET=true
+    fi
+
+    #Checking Compose V1 availablity
+    docker-compose version >/dev/null 2>&1
+    if [ $? -eq 0 ]; then status_v1=true; else status_v1=false; fi
+
+    #Checking Compose V2 availablity
+    docker compose version >/dev/null 2>&1
+    if [ $? -eq 0 ]; then status_v2=true; else status_v2=false; fi
+
+    COMPOSE_VERSION=""
+
+    if $status_v2 ; then
+        COMPOSE_VERSION="V2"
+    elif $status_v1 ; then
+        COMPOSE_VERSION="V1"
+    else
+        echo "Docker Compose plugin is not detected. Please check your environment." >&2
+        exit 1
+    fi
+
+    echo $COMPOSE_VERSION
+
+    if $FLAG_SET ; then set -e; fi
 }

--- a/docker-install-tb.sh
+++ b/docker-install-tb.sh
@@ -73,13 +73,13 @@ checkFolders --create || exit $?
 cd $DEPLOYMENT_FOLDER
 
 if [ ! -z "${ADDITIONAL_STARTUP_SERVICES// }" ]; then
-    docker-compose \
+    docker compose \
       --env-file ../.env \
       -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
       up -d $ADDITIONAL_STARTUP_SERVICES
 fi
 
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
   run --no-deps --rm -e INSTALL_TB=true -e LOAD_DEMO=${loadDemo} \

--- a/docker-remove-services.sh
+++ b/docker-remove-services.sh
@@ -2,7 +2,7 @@
 #
 # ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
 #
-# Copyright © 2016-2019 ThingsBoard, Inc. All Rights Reserved.
+# Copyright © 2016-2022 ThingsBoard, Inc. All Rights Reserved.
 #
 # NOTICE: All information contained herein is, and remains
 # the property of ThingsBoard, Inc. and its suppliers,
@@ -34,6 +34,8 @@ set -e
 
 source compose-utils.sh
 
+COMPOSE_VERSION=$(composeVersion) || exit $?
+
 DEPLOYMENT_FOLDER=$(deploymentFolder) || exit $?
 
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
@@ -46,9 +48,21 @@ ADDITIONAL_COMPOSE_MONITORING_ARGS=$(additionalComposeMonitoringArgs) || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker compose \
-  --env-file ../.env \
-  -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS $ADDITIONAL_COMPOSE_MONITORING_ARGS \
-  down -v
+COMPOSE_ARGS="\
+      --env-file ../.env \
+      -f docker-compose.yml ${ADDITIONAL_CACHE_ARGS} ${ADDITIONAL_COMPOSE_ARGS} ${ADDITIONAL_COMPOSE_QUEUE_ARGS} ${ADDITIONAL_COMPOSE_MONITORING_ARGS} \
+      down -v"
+
+case $COMPOSE_VERSION in
+    V2)
+        docker compose $COMPOSE_ARGS
+    ;;
+    V1)
+        docker-compose $COMPOSE_ARGS
+    ;;
+    *)
+        # unknown option
+    ;;
+esac
 
 cd ~-

--- a/docker-remove-services.sh
+++ b/docker-remove-services.sh
@@ -46,7 +46,7 @@ ADDITIONAL_COMPOSE_MONITORING_ARGS=$(additionalComposeMonitoringArgs) || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS $ADDITIONAL_COMPOSE_MONITORING_ARGS \
   down -v

--- a/docker-start-services.sh
+++ b/docker-start-services.sh
@@ -2,7 +2,7 @@
 #
 # ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
 #
-# Copyright © 2016-2021 ThingsBoard, Inc. All Rights Reserved.
+# Copyright © 2016-2022 ThingsBoard, Inc. All Rights Reserved.
 #
 # NOTICE: All information contained herein is, and remains
 # the property of ThingsBoard, Inc. and its suppliers,
@@ -34,6 +34,8 @@ set -e
 
 source compose-utils.sh
 
+COMPOSE_VERSION=$(composeVersion) || exit $?
+
 DEPLOYMENT_FOLDER=$(deploymentFolder) || exit $?
 
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
@@ -48,9 +50,21 @@ checkFolders --create || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker compose \
-  --env-file ../.env \
-  -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS $ADDITIONAL_COMPOSE_MONITORING_ARGS \
-  up -d
+COMPOSE_ARGS="\
+      --env-file ../.env \
+      -f docker-compose.yml ${ADDITIONAL_CACHE_ARGS} ${ADDITIONAL_COMPOSE_ARGS} ${ADDITIONAL_COMPOSE_QUEUE_ARGS} ${ADDITIONAL_COMPOSE_MONITORING_ARGS} \
+      up -d"
+
+case $COMPOSE_VERSION in
+    V2)
+        docker compose $COMPOSE_ARGS
+    ;;
+    V1)
+        docker-compose $COMPOSE_ARGS
+    ;;
+    *)
+        # unknown option
+    ;;
+esac
 
 cd ~-

--- a/docker-start-services.sh
+++ b/docker-start-services.sh
@@ -48,7 +48,7 @@ checkFolders --create || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS $ADDITIONAL_COMPOSE_MONITORING_ARGS \
   up -d

--- a/docker-stop-services.sh
+++ b/docker-stop-services.sh
@@ -46,7 +46,7 @@ ADDITIONAL_COMPOSE_MONITORING_ARGS=$(additionalComposeMonitoringArgs) || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS $ADDITIONAL_COMPOSE_MONITORING_ARGS \
   stop

--- a/docker-stop-services.sh
+++ b/docker-stop-services.sh
@@ -2,7 +2,7 @@
 #
 # ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
 #
-# Copyright © 2016-2021 ThingsBoard, Inc. All Rights Reserved.
+# Copyright © 2016-2022 ThingsBoard, Inc. All Rights Reserved.
 #
 # NOTICE: All information contained herein is, and remains
 # the property of ThingsBoard, Inc. and its suppliers,
@@ -34,6 +34,8 @@ set -e
 
 source compose-utils.sh
 
+COMPOSE_VERSION=$(composeVersion) || exit $?
+
 DEPLOYMENT_FOLDER=$(deploymentFolder) || exit $?
 
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
@@ -46,9 +48,21 @@ ADDITIONAL_COMPOSE_MONITORING_ARGS=$(additionalComposeMonitoringArgs) || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker compose \
-  --env-file ../.env \
-  -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS $ADDITIONAL_COMPOSE_MONITORING_ARGS \
-  stop
+COMPOSE_ARGS="\
+      --env-file ../.env \
+      -f docker-compose.yml ${ADDITIONAL_CACHE_ARGS} ${ADDITIONAL_COMPOSE_ARGS} ${ADDITIONAL_COMPOSE_QUEUE_ARGS} ${ADDITIONAL_COMPOSE_MONITORING_ARGS} \
+      stop"
+
+case $COMPOSE_VERSION in
+    V2)
+        docker compose $COMPOSE_ARGS
+    ;;
+    V1)
+        docker-compose $COMPOSE_ARGS
+    ;;
+    *)
+        # unknown option
+    ;;
+esac
 
 cd ~-

--- a/docker-update-service.sh
+++ b/docker-update-service.sh
@@ -2,7 +2,7 @@
 #
 # ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
 #
-# Copyright © 2016-2021 ThingsBoard, Inc. All Rights Reserved.
+# Copyright © 2016-2022 ThingsBoard, Inc. All Rights Reserved.
 #
 # NOTICE: All information contained herein is, and remains
 # the property of ThingsBoard, Inc. and its suppliers,
@@ -34,6 +34,8 @@ set -e
 
 source compose-utils.sh
 
+COMPOSE_VERSION=$(composeVersion) || exit $?
+
 DEPLOYMENT_FOLDER=$(deploymentFolder) || exit $?
 
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
@@ -44,13 +46,28 @@ ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker compose \
-  --env-file ../.env \
-  -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
-  pull $@
-docker compose \
-  --env-file ../.env \
-  -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
-  up -d --no-deps --build $@
+COMPOSE_ARGS_PULL="\
+      --env-file ../.env \
+      -f docker-compose.yml ${ADDITIONAL_CACHE_ARGS} ${ADDITIONAL_COMPOSE_ARGS} ${ADDITIONAL_COMPOSE_QUEUE_ARGS} \
+      pull"
+
+COMPOSE_ARGS_BUILD="\
+      --env-file ../.env \
+      -f docker-compose.yml ${ADDITIONAL_CACHE_ARGS} ${ADDITIONAL_COMPOSE_ARGS} ${ADDITIONAL_COMPOSE_QUEUE_ARGS} \
+      up -d --no-deps --build"
+
+case $COMPOSE_VERSION in
+    V2)
+        docker compose $COMPOSE_ARGS_PULL $@
+        docker compose $COMPOSE_ARGS_BUILD $@
+    ;;
+    V1)
+        docker-compose $COMPOSE_ARGS_PULL $@
+        docker-compose $COMPOSE_ARGS_BUILD $@
+    ;;
+    *)
+        # unknown option
+    ;;
+esac
 
 cd ~-

--- a/docker-update-service.sh
+++ b/docker-update-service.sh
@@ -44,11 +44,11 @@ ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
   pull $@
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
   up -d --no-deps --build $@

--- a/docker-upgrade-tb.sh
+++ b/docker-upgrade-tb.sh
@@ -71,18 +71,18 @@ checkFolders --create || exit $?
 
 cd $DEPLOYMENT_FOLDER
 
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
   pull \
   $MAIN_SERVICE_NAME
 
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
   up -d $ADDITIONAL_STARTUP_SERVICES
 
-docker-compose \
+docker compose \
   --env-file ../.env \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \
   run --no-deps --rm -e UPGRADE_TB=true -e FROM_VERSION=${fromVersion} \

--- a/monolith/docker-compose.yml
+++ b/monolith/docker-compose.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '2.2'
-
 services:
   zookeeper:
     restart: always
@@ -44,7 +42,8 @@ services:
   tb-js-executor:
     restart: always
     image: "${DOCKER_REPO}/${JS_EXECUTOR_DOCKER_NAME}:${TB_VERSION}"
-    scale: 10
+    deploy:
+      replicas: 10
     env_file:
       - ../tb-js-executor.env
   tb-monolith:


### PR DESCRIPTION
Docker microservices installation (aka Docker Compose installation) have been using an outdated Compose V1. As Docker no longer support V1 and there are differences between V1 and V2, some script and compose file changes were required.

- remove `version` tag, as it is deprecated in V2;
- change `scale` to `deploy.replicas` due to deprecation and weird interactions with multiple "-f" flags;
- change `docker-compose` to `docker compose` that corresponds to migration to V2.

Documentation changes are not required, as Docker instructions already use Compose V2 only.