### PR TITLE
Update haproxy.cfg - fix server name

### DIFF
--- a/monolith/haproxy/config/haproxy.cfg
+++ b/monolith/haproxy/config/haproxy.cfg
@@ -132,7 +132,7 @@ backend tb-http-backend
   balance leastconn
   option tcp-check
   option log-health-checks
-  server tbHttp monolith:8080 check inter 5s resolvers docker_resolver resolve-prefer ipv4
+  server tbHttp tb-monolith:8080 check inter 5s resolvers docker_resolver resolve-prefer ipv4
 
 backend tb-api-backend
   balance leastconn


### PR DESCRIPTION
Due to incorrect configuration, /api/v1/ was not working.
Fixed service name to `tb-monolith`, since docker service `monolith` does not exist.