### PR TITLE
Prometheus version updated to 3.1.0

### DIFF
--- a/advanced/docker-compose.prometheus-grafana.yml
+++ b/advanced/docker-compose.prometheus-grafana.yml
@@ -38,7 +38,7 @@ volumes:
 services:
 
   prometheus:
-    image: prom/prometheus:v2.1.0
+    image: prom/prometheus:v3.1.0
     volumes:
       - ./monitoring/prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus

--- a/basic/docker-compose.prometheus-grafana.yml
+++ b/basic/docker-compose.prometheus-grafana.yml
@@ -38,7 +38,7 @@ volumes:
 services:
 
   prometheus:
-    image: prom/prometheus:v2.1.0
+    image: prom/prometheus:v3.1.0
     volumes:
       - ./monitoring/prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus

--- a/monolith/docker-compose.prometheus-grafana.yml
+++ b/monolith/docker-compose.prometheus-grafana.yml
@@ -38,7 +38,7 @@ volumes:
 services:
 
   prometheus:
-    image: prom/prometheus:v2.1.0
+    image: prom/prometheus:v3.1.0
     volumes:
       - ./monitoring/prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus


### PR DESCRIPTION
The current Prometheus docker image is 2.1.0, built 7 years ago, and not compatible with the current docker-compose version. It throws an error, and services don't start. 
```
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/prom/prometheus:v2.1.0 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```
Updating the image to version 3.1.0 fixes the problem. The newer Prometheus version is compatible with Thingsboard services and dashboards on Grafana display collected metrics.  