### PR TITLE
removed version property from docker-compose

### DIFF
--- a/advanced/docker-compose.cassandra.volumes.yml
+++ b/advanced/docker-compose.cassandra.volumes.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   cassandra:
     volumes:

--- a/advanced/docker-compose.confluent.yml
+++ b/advanced/docker-compose.confluent.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   tb-js-executor:
     env_file:

--- a/advanced/docker-compose.edqs.volumes.yml
+++ b/advanced/docker-compose.edqs.volumes.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   tb-edqs1:
     volumes:

--- a/advanced/docker-compose.edqs.yml
+++ b/advanced/docker-compose.edqs.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   tb-core1:
     env_file:

--- a/advanced/docker-compose.hybrid.yml
+++ b/advanced/docker-compose.hybrid.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   postgres:
     restart: always

--- a/advanced/docker-compose.kafka.yml
+++ b/advanced/docker-compose.kafka.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   kafka:
     restart: always

--- a/advanced/docker-compose.postgres.volumes.yml
+++ b/advanced/docker-compose.postgres.volumes.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   postgres:
     volumes:

--- a/advanced/docker-compose.postgres.yml
+++ b/advanced/docker-compose.postgres.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   postgres:
     restart: always

--- a/advanced/docker-compose.prometheus-grafana.yml
+++ b/advanced/docker-compose.prometheus-grafana.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 volumes:
     prometheus_data: {}
     grafana_data: {}

--- a/advanced/docker-compose.valkey-cluster.volumes.yml
+++ b/advanced/docker-compose.valkey-cluster.volumes.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   # Valkey cluster
   valkey-node-0:

--- a/advanced/docker-compose.valkey-cluster.yml
+++ b/advanced/docker-compose.valkey-cluster.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
 # Valkey cluster
 # The latest version of Valkey compatible with ThingsBoard is 8.0

--- a/advanced/docker-compose.valkey-sentinel.volumes.yml
+++ b/advanced/docker-compose.valkey-sentinel.volumes.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   # Valkey sentinel
   valkey-primary:

--- a/advanced/docker-compose.valkey-sentinel.yml
+++ b/advanced/docker-compose.valkey-sentinel.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   # Valkey sentinel
   # The latest version of Valkey compatible with ThingsBoard is 8.0

--- a/advanced/docker-compose.valkey.volumes.yml
+++ b/advanced/docker-compose.valkey.volumes.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   valkey:
     volumes:

--- a/advanced/docker-compose.valkey.yml
+++ b/advanced/docker-compose.valkey.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
 # Valkey standalone
 # The latest version of Valkey compatible with ThingsBoard is 8.0

--- a/advanced/docker-compose.volumes.yml
+++ b/advanced/docker-compose.volumes.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   tb-core1:
     volumes:

--- a/advanced/docker-compose.yml
+++ b/advanced/docker-compose.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   zookeeper:
     restart: always

--- a/basic/docker-compose.confluent.yml
+++ b/basic/docker-compose.confluent.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   tb-js-executor:
     env_file:

--- a/basic/docker-compose.hybrid.yml
+++ b/basic/docker-compose.hybrid.yml
@@ -27,8 +27,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   postgres:
     restart: always

--- a/basic/docker-compose.kafka.yml
+++ b/basic/docker-compose.kafka.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   kafka:
     restart: always

--- a/basic/docker-compose.postgres.yml
+++ b/basic/docker-compose.postgres.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   postgres:
     restart: always

--- a/basic/docker-compose.prometheus-grafana.yml
+++ b/basic/docker-compose.prometheus-grafana.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 volumes:
     prometheus_data: {}
     grafana_data: {}

--- a/basic/docker-compose.valkey-cluster.yml
+++ b/basic/docker-compose.valkey-cluster.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
 # Valkey cluster
 # The latest version of Valkey compatible with ThingsBoard is 8.0

--- a/basic/docker-compose.valkey-sentinel.yml
+++ b/basic/docker-compose.valkey-sentinel.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   # Valkey sentinel
   # The latest version of Valkey compatible with ThingsBoard is 8.0

--- a/basic/docker-compose.valkey.yml
+++ b/basic/docker-compose.valkey.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
 # Valkey standalone
 # The latest version of Valkey compatible with ThingsBoard is 8.0

--- a/basic/docker-compose.yml
+++ b/basic/docker-compose.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   zookeeper:
     restart: always

--- a/monolith/docker-compose.confluent.yml
+++ b/monolith/docker-compose.confluent.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   tb-js-executor:
     env_file:

--- a/monolith/docker-compose.hybrid.yml
+++ b/monolith/docker-compose.hybrid.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   postgres:
     restart: always

--- a/monolith/docker-compose.kafka.yml
+++ b/monolith/docker-compose.kafka.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   kafka:
     restart: always

--- a/monolith/docker-compose.postgres.yml
+++ b/monolith/docker-compose.postgres.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   postgres:
     restart: always

--- a/monolith/docker-compose.prometheus-grafana.yml
+++ b/monolith/docker-compose.prometheus-grafana.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 volumes:
     prometheus_data: {}
     grafana_data: {}

--- a/monolith/docker-compose.valkey-cluster.yml
+++ b/monolith/docker-compose.valkey-cluster.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
 # Valkey cluster
 # The latest version of Valkey compatible with ThingsBoard is 8.0

--- a/monolith/docker-compose.valkey-sentinel.yml
+++ b/monolith/docker-compose.valkey-sentinel.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   # Valkey sentinel
   # The latest version of valkey compatible with ThingsBoard is 8.0

--- a/monolith/docker-compose.valkey.yml
+++ b/monolith/docker-compose.valkey.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
 # Valkey standalone
 # The latest version of Valkey compatible with ThingsBoard is 8.0

--- a/monolith/docker-compose.yml
+++ b/monolith/docker-compose.yml
@@ -29,8 +29,6 @@
 # OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
 #
 
-version: '3.0'
-
 services:
   zookeeper:
     restart: always


### PR DESCRIPTION
## Pull Request description

Removed `version` property from all docker-compose to remove the following warning
```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

PR Reference for thingsboard repo, addressing same set of changes : [PR-13722](https://github.com/thingsboard/thingsboard/pull/13722)