### PR TITLE
Security: enable Node.js Permission Model for JS executor

### DIFF
--- a/tb-js-executor.env
+++ b/tb-js-executor.env
@@ -4,4 +4,4 @@ LOG_FOLDER=logs
 LOGGER_FILENAME=tb-js-executor-%DATE%.log
 DOCKER_MODE=true
 SCRIPT_BODY_TRACE_FREQUENCY=1000
-NODE_OPTIONS="--max-old-space-size=200"
+NODE_OPTIONS="--max-old-space-size=200 --permission --allow-fs-read=/usr/share/tb-js-executor/*"


### PR DESCRIPTION
Add --permission and --allow-fs-read=/usr/share/tb-js-executor/* to NODE_OPTIONS to restrict filesystem access and sandbox script execution.